### PR TITLE
update copyright and absolute path of og image

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 stepzen-dev
+Copyright (c) 2022 stepzen-dev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <meta name="og:site_name" content="JSON2SDL" />
     <meta name="og:type" content="website" />
     <meta name="og:url" content="https://json2sdl.com" />
-    <meta name="og:image" content="./assets/images/social-share.jpg" />
+    <meta name="og:image" content="https://json2sdl.com/assets/images/social-share.jpg" />
     <meta name="og:locale" content="en_US" />
     <meta name="twitter:creator" content="@stepzen_dev" />
     <meta name="twitter:site" content="@stepzen_dev" />
@@ -149,7 +149,7 @@
     </main>
     <footer class="app-footer">
       <div class="container">
-        <small>&copy; 2021 StepZen, Inc.</small>
+        <small>&copy; 2022 StepZen, Inc.</small>
 
         <nav class="app-footer-nav">
           <h2>Connect</h2>

--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 StepZen, Inc.
+Copyright (c) 2022 StepZen, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The OG Image for social must be absolute rather than relative.

Copyright 2021 --> 2022